### PR TITLE
report motor overload ratio

### DIFF
--- a/src/CurrentState.hpp
+++ b/src/CurrentState.hpp
@@ -15,6 +15,9 @@ namespace motors_weg_cvw300 {
         float inverter_output_voltage;
         float inverter_output_frequency;
 
+        /** Motor overload in percent (between 0 and 1) */
+        float motor_overload_ratio;
+
         InverterStatus inverter_status;
     };
 }

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -228,9 +228,8 @@ CurrentState Driver::readCurrentState() {
     uint16_t values[R_ENCODER_SPEED + 2];
 
     readRegisters(values + R_MOTOR_SPEED, m_address, false, R_MOTOR_SPEED, 8);
-    if (m_use_encoder_feedback) {
-        readRegisters(values + R_ENCODER_SPEED, m_address, false, R_ENCODER_SPEED, 2);
-    }
+    readRegisters(values + R_MOTOR_OVERLOAD, m_address, false, R_MOTOR_OVERLOAD,
+                  m_use_encoder_feedback ? 3 : 1);
 
     CurrentState state;
     if (m_use_encoder_feedback) {
@@ -248,6 +247,7 @@ CurrentState Driver::readCurrentState() {
         state.motor.speed = decodeRegister<float>(
             values[R_MOTOR_SPEED]) * 2 * M_PI / 60;
     }
+    state.motor_overload_ratio = decodeRegister<float>(values[R_MOTOR_OVERLOAD]) / 100;
     state.motor.raw = decodeRegister<float>(
         values[R_INVERTER_OUTPUT_CURRENT]) / 10;
     state.battery_voltage = decodeRegister<float>(

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -32,6 +32,7 @@ namespace motors_weg_cvw300 {
             R_MOTOR_TORQUE = 9,
             R_TEMPERATURE_MOSFET = 30,
             R_TEMPERATURE_AIR = 34,
+            R_MOTOR_OVERLOAD = 37,
             R_ENCODER_SPEED = 38,
             R_ENCODER_PULSE_COUNTER = 39,
 


### PR DESCRIPTION
It's an estimate of how "hot" the motor is, that is how far we can
still got before we have to shut it down. Crossing the 100% threshold
causes an alarm/fault, so report it to allow us to log it.