### PR TITLE
chore: Move the writeSingleRegister method to be public

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,6 @@
 # executed from 'project/build' with 'cmake ../'.
 cmake_minimum_required(VERSION 2.6)
 find_package(Rock)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 rock_init(motors_weg_cvw300 0.1)
 rock_standard_layout()

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -87,9 +87,6 @@ namespace motors_weg_cvw300 {
         template<typename T>
         T readSingleRegister(int register_id);
 
-        template<typename T>
-        void writeSingleRegister(int register_id, T value);
-
         void writeJointTorqueLimit(float limit, int register_id);
 
     public:
@@ -175,6 +172,10 @@ namespace motors_weg_cvw300 {
 
         /** Change the ramp configuration */
         void writeRampConfiguration(configuration::Ramps const& ramps);
+
+        /** Write the value into register */
+        template<typename T>
+        void writeSingleRegister(int register_id, T value);
 
         CurrentState readCurrentState();
 


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
To be able to implement the configuration of registers through a component property, it was necessary to make the `writeSingleRegister` method public.
[sc-39822]

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR