### PR TITLE
feat: Add a prepare command to motors_weg_cvw300_ctl

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -124,6 +124,11 @@ int main(int argc, char** argv)
                  << setw(6) << state.motor.raw << "\n";
         }
     }
+    else if (cmd == "prepare") {
+        Driver driver(id);
+        driver.openURI(uri);
+        driver.prepare();
+    }
     else if (cmd == "fault-state") {
         Driver driver(id);
         driver.readMotorRatings();

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -131,6 +131,7 @@ int main(int argc, char** argv)
     }
     else if (cmd == "fault-state") {
         Driver driver(id);
+        driver.openURI(uri);
         driver.readMotorRatings();
         auto state = driver.readFaultState();
         cout << "Current Fault: " << state.current_fault << "\n"


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
The motors_weg_cvw300_ctl prepare should reset all controller faults. 
[sc-59811]

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
