### PR TITLE
feat: add reset fault behavior

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -74,6 +74,18 @@ void Driver::prepare() {
     );
 }
 
+void Driver::resetFault() {
+    writeSingleRegister<int16_t>(
+        R_SERIAL_STATUS_WORD,
+        configuration::SERIAL_MODE_REMOTE |
+        configuration::SERIAL_RESET_FAULT
+    );
+    writeSingleRegister<int16_t>(
+        R_SERIAL_STATUS_WORD,
+        configuration::SERIAL_MODE_REMOTE
+    );
+}
+
 void Driver::enable() {
     writeSingleRegister<int16_t>(
         R_SERIAL_STATUS_WORD,

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -147,6 +147,9 @@ namespace motors_weg_cvw300 {
         /** Prepare the unit to receive control from the driver w/o enabling power */
         void prepare();
 
+        /** Resets a fault state */
+        void resetFault();
+
         /** Enable the motor control, and give control to the serial interface */
         void enable();
 


### PR DESCRIPTION
Toggles the fault reset bit on and off to signal a fault reset in the controller's software

<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [ ] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
